### PR TITLE
[D100P-43] 日付選択のcomponentを作成する

### DIFF
--- a/app/src/main/java/com/rnk0085/selfcare/ui/Utils.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/Utils.kt
@@ -1,0 +1,3 @@
+package com.rnk0085.selfcare.ui
+
+val currentTimeMillis = System.currentTimeMillis()

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/ReflectionScreen.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/ReflectionScreen.kt
@@ -8,15 +8,24 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.rnk0085.selfcare.ui.screen.component.SelfcareTopAppBar
+import com.rnk0085.selfcare.ui.screen.reflection.component.DatePickerModal
+import com.rnk0085.selfcare.ui.screen.reflection.component.DiaryDatePickerButton
 
 @Composable
 internal fun ReflectionScreen(
     onBackClicked: () -> Unit,
 ) {
+    var showDatePicker by remember { mutableStateOf(false) }
+
     Scaffold(
         topBar = {
             SelfcareTopAppBar(
@@ -28,11 +37,21 @@ internal fun ReflectionScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(innerPadding),
+                .padding(innerPadding)
+                .padding(horizontal = 16.dp),
             verticalArrangement = Arrangement.SpaceEvenly,
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            Text("ふりかえり画面")
+            DiaryDatePickerButton(
+                onClick = { showDatePicker = true },
+            )
+
+            if (showDatePicker) {
+                DatePickerModal(
+                    onDateSelected = { /* TODO */ },
+                    onDismiss = { showDatePicker = false },
+                )
+            }
 
             Button(onClick = { /* TODO */ }) {
                 Text("記録する")

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/ReflectionScreen.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/ReflectionScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -16,6 +17,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.rnk0085.selfcare.ui.currentTimeMillis
 import com.rnk0085.selfcare.ui.screen.component.SelfcareTopAppBar
 import com.rnk0085.selfcare.ui.screen.reflection.component.DatePickerModal
 import com.rnk0085.selfcare.ui.screen.reflection.component.DiaryDatePickerButton
@@ -24,7 +26,7 @@ import com.rnk0085.selfcare.ui.screen.reflection.component.DiaryDatePickerButton
 internal fun ReflectionScreen(
     onBackClicked: () -> Unit,
 ) {
-    var selectedDate by remember { mutableStateOf(System.currentTimeMillis()) }
+    var selectedDate by remember { mutableLongStateOf(currentTimeMillis) }
     var showDatePicker by remember { mutableStateOf(false) }
 
     Scaffold(
@@ -51,7 +53,7 @@ internal fun ReflectionScreen(
             if (showDatePicker) {
                 DatePickerModal(
                     onDateSelected = {
-                        selectedDate = it ?: System.currentTimeMillis()
+                        selectedDate = it ?: currentTimeMillis
                         showDatePicker = false
                     },
                     onDismiss = { showDatePicker = false },

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/ReflectionScreen.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/ReflectionScreen.kt
@@ -24,6 +24,7 @@ import com.rnk0085.selfcare.ui.screen.reflection.component.DiaryDatePickerButton
 internal fun ReflectionScreen(
     onBackClicked: () -> Unit,
 ) {
+    var selectedDate by remember { mutableStateOf(System.currentTimeMillis()) }
     var showDatePicker by remember { mutableStateOf(false) }
 
     Scaffold(
@@ -43,12 +44,16 @@ internal fun ReflectionScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             DiaryDatePickerButton(
+                selectedDate = selectedDate,
                 onClick = { showDatePicker = true },
             )
 
             if (showDatePicker) {
                 DatePickerModal(
-                    onDateSelected = { /* TODO */ },
+                    onDateSelected = {
+                        selectedDate = it ?: System.currentTimeMillis()
+                        showDatePicker = false
+                    },
                     onDismiss = { showDatePicker = false },
                 )
             }

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/component/DatePickerModal.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/component/DatePickerModal.kt
@@ -1,0 +1,47 @@
+package com.rnk0085.selfcare.ui.screen.reflection.component
+
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.runtime.Composable
+
+// https://developer.android.com/develop/ui/compose/components/datepickers#modal
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun DatePickerModal(
+    onDateSelected: (Long?) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val datePickerState = rememberDatePickerState()
+
+    DatePickerDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    onDateSelected(datePickerState.selectedDateMillis)
+                    onDismiss()
+                }
+            ) {
+                Text(
+                    text = "OK",
+                    style = MaterialTheme.typography.labelLarge,
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(
+                    text = "Cancel",
+                    style = MaterialTheme.typography.labelLarge,
+                )
+            }
+        },
+    ) {
+        DatePicker(state = datePickerState)
+    }
+}

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/component/DatePickerModal.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/component/DatePickerModal.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import com.rnk0085.selfcare.R
+import com.rnk0085.selfcare.ui.currentTimeMillis
 
 // https://developer.android.com/develop/ui/compose/components/datepickers#modal
 @OptIn(ExperimentalMaterial3Api::class)
@@ -20,7 +21,7 @@ internal fun DatePickerModal(
     onDismiss: () -> Unit,
 ) {
     val datePickerState = rememberDatePickerState(
-        initialSelectedDateMillis = System.currentTimeMillis(),
+        initialSelectedDateMillis = currentTimeMillis,
         selectableDates = NoFutureDate,
     )
 
@@ -58,6 +59,6 @@ internal fun DatePickerModal(
 @OptIn(ExperimentalMaterial3Api::class)
 val NoFutureDate : SelectableDates = object : SelectableDates {
     override fun isSelectableDate(utcTimeMillis: Long): Boolean {
-        return utcTimeMillis <= System.currentTimeMillis()
+        return utcTimeMillis <= currentTimeMillis
     }
 }

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/component/DatePickerModal.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/component/DatePickerModal.kt
@@ -4,6 +4,7 @@ import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SelectableDates
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberDatePickerState
@@ -16,7 +17,10 @@ internal fun DatePickerModal(
     onDateSelected: (Long?) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    val datePickerState = rememberDatePickerState()
+    val datePickerState = rememberDatePickerState(
+        initialSelectedDateMillis = System.currentTimeMillis(),
+        selectableDates = NoFutureDate,
+    )
 
     DatePickerDialog(
         onDismissRequest = onDismiss,
@@ -42,6 +46,16 @@ internal fun DatePickerModal(
             }
         },
     ) {
-        DatePicker(state = datePickerState)
+        DatePicker(
+            state = datePickerState,
+        )
+    }
+}
+
+// 明日以降の日付を選択不可にする
+@OptIn(ExperimentalMaterial3Api::class)
+val NoFutureDate : SelectableDates = object : SelectableDates {
+    override fun isSelectableDate(utcTimeMillis: Long): Boolean {
+        return utcTimeMillis <= System.currentTimeMillis()
     }
 }

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/component/DatePickerModal.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/component/DatePickerModal.kt
@@ -9,6 +9,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.rnk0085.selfcare.R
 
 // https://developer.android.com/develop/ui/compose/components/datepickers#modal
 @OptIn(ExperimentalMaterial3Api::class)
@@ -32,7 +34,7 @@ internal fun DatePickerModal(
                 }
             ) {
                 Text(
-                    text = "OK",
+                    text = stringResource(R.string.ok),
                     style = MaterialTheme.typography.labelLarge,
                 )
             }
@@ -40,7 +42,7 @@ internal fun DatePickerModal(
         dismissButton = {
             TextButton(onClick = onDismiss) {
                 Text(
-                    text = "Cancel",
+                    text = stringResource(R.string.cancel),
                     style = MaterialTheme.typography.labelLarge,
                 )
             }

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/component/DiaryDatePicker.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/component/DiaryDatePicker.kt
@@ -1,0 +1,71 @@
+package com.rnk0085.selfcare.ui.screen.reflection.component
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@Composable
+internal fun DiaryDatePicker(
+    modifier: Modifier = Modifier,
+) {
+    var selectedDate by remember { mutableStateOf(System.currentTimeMillis()) }
+
+    OutlinedButton(
+        onClick = { /* TODO */ },
+        shape = RoundedCornerShape(8.dp),
+        colors = ButtonDefaults.outlinedButtonColors(
+            contentColor = MaterialTheme.colorScheme.onSurface,
+            containerColor = MaterialTheme.colorScheme.surface,
+        ),
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = Icons.Default.DateRange,
+                contentDescription = null,
+            )
+
+            Spacer(modifier = Modifier.width(8.dp))
+
+            Text(
+                text = convertMillisToDate(selectedDate),
+                style = MaterialTheme.typography.labelMedium,
+            )
+        }
+    }
+}
+
+private fun convertMillisToDate(millis: Long): String {
+    val formater = SimpleDateFormat("yyyy/MM/dd(EEE)", Locale.getDefault())
+    return formater.format(Date(millis))
+}
+
+@Composable
+@Preview
+private fun DiaryDatePickerPreview() {
+    DiaryDatePicker()
+}

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/component/DiaryDatePickerButton.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/component/DiaryDatePickerButton.kt
@@ -26,13 +26,14 @@ import java.util.Date
 import java.util.Locale
 
 @Composable
-internal fun DiaryDatePicker(
+internal fun DiaryDatePickerButton(
+    onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var selectedDate by remember { mutableStateOf(System.currentTimeMillis()) }
 
     OutlinedButton(
-        onClick = { /* TODO */ },
+        onClick = onClick,
         shape = RoundedCornerShape(8.dp),
         colors = ButtonDefaults.outlinedButtonColors(
             contentColor = MaterialTheme.colorScheme.onSurface,
@@ -53,7 +54,7 @@ internal fun DiaryDatePicker(
 
             Text(
                 text = convertMillisToDate(selectedDate),
-                style = MaterialTheme.typography.labelMedium,
+                style = MaterialTheme.typography.labelLarge,
             )
         }
     }
@@ -66,6 +67,8 @@ private fun convertMillisToDate(millis: Long): String {
 
 @Composable
 @Preview
-private fun DiaryDatePickerPreview() {
-    DiaryDatePicker()
+private fun DiaryDatePickerButtonPreview() {
+    DiaryDatePickerButton(
+        onClick = {},
+    )
 }

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/component/DiaryDatePickerButton.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/component/DiaryDatePickerButton.kt
@@ -13,10 +13,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -27,11 +23,10 @@ import java.util.Locale
 
 @Composable
 internal fun DiaryDatePickerButton(
+    selectedDate: Long,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var selectedDate by remember { mutableStateOf(System.currentTimeMillis()) }
-
     OutlinedButton(
         onClick = onClick,
         shape = RoundedCornerShape(8.dp),
@@ -69,6 +64,7 @@ private fun convertMillisToDate(millis: Long): String {
 @Preview
 private fun DiaryDatePickerButtonPreview() {
     DiaryDatePickerButton(
+        selectedDate = System.currentTimeMillis(),
         onClick = {},
     )
 }

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/component/DiaryDatePickerButton.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/component/DiaryDatePickerButton.kt
@@ -5,20 +5,20 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.rnk0085.selfcare.ui.theme.sectionContainerColor
+import com.rnk0085.selfcare.ui.theme.sectionContentColor
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -29,12 +29,12 @@ internal fun DiaryDatePickerButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    OutlinedButton(
+    Button(
         onClick = onClick,
-        shape = RoundedCornerShape(8.dp),
-        colors = ButtonDefaults.outlinedButtonColors(
-            contentColor = Color.Black,
-            containerColor = Color.White,
+        shape = MaterialTheme.shapes.small,
+        colors = ButtonDefaults.buttonColors(
+            contentColor = sectionContentColor,
+            containerColor = sectionContainerColor,
         ),
         modifier = modifier.fillMaxWidth(),
     ) {

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/component/DiaryDatePickerButton.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/component/DiaryDatePickerButton.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.rnk0085.selfcare.ui.currentTimeMillis
 import com.rnk0085.selfcare.ui.theme.sectionContainerColor
 import com.rnk0085.selfcare.ui.theme.sectionContentColor
 import java.text.SimpleDateFormat
@@ -67,7 +68,7 @@ private fun convertMillisToDate(millis: Long): String {
 @Preview
 private fun DiaryDatePickerButtonPreview() {
     DiaryDatePickerButton(
-        selectedDate = System.currentTimeMillis(),
+        selectedDate = currentTimeMillis,
         onClick = {},
     )
 }

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/component/DiaryDatePickerButton.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/component/DiaryDatePickerButton.kt
@@ -3,6 +3,7 @@ package com.rnk0085.selfcare.ui.screen.reflection.component
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -15,6 +16,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import java.text.SimpleDateFormat
@@ -31,8 +33,8 @@ internal fun DiaryDatePickerButton(
         onClick = onClick,
         shape = RoundedCornerShape(8.dp),
         colors = ButtonDefaults.outlinedButtonColors(
-            contentColor = MaterialTheme.colorScheme.onSurface,
-            containerColor = MaterialTheme.colorScheme.surface,
+            contentColor = Color.Black,
+            containerColor = Color.White,
         ),
         modifier = modifier.fillMaxWidth(),
     ) {
@@ -43,13 +45,14 @@ internal fun DiaryDatePickerButton(
             Icon(
                 imageVector = Icons.Default.DateRange,
                 contentDescription = null,
+                modifier = Modifier.size(48.dp),
             )
 
             Spacer(modifier = Modifier.width(8.dp))
 
             Text(
                 text = convertMillisToDate(selectedDate),
-                style = MaterialTheme.typography.labelLarge,
+                style = MaterialTheme.typography.headlineMedium,
             )
         }
     }

--- a/app/src/main/java/com/rnk0085/selfcare/ui/theme/Color.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/theme/Color.kt
@@ -9,3 +9,8 @@ val Pink80 = Color(0xFFEFB8C8)
 val Purple40 = Color(0xFF6650a4)
 val PurpleGrey40 = Color(0xFF625b71)
 val Pink40 = Color(0xFF7D5260)
+
+// TODO: 適切な命名、カラーに変更する
+// カードや記録する場所で使用予定
+val sectionContainerColor = Color.White
+val sectionContentColor = Color.Black

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,5 @@
 <resources>
     <string name="app_name">selfcare</string>
+    <string name="ok">OK</string>
+    <string name="cancel">キャンセル</string>
 </resources>


### PR DESCRIPTION
## 概要

- 何をしたのか、どんなことが出来るようになったのか

### チケット番号

D100P-43

## やったこと

- [Modal date picker](https://developer.android.com/develop/ui/compose/components/datepickers#modal) を活用してカレンダーから日付を選択できるようにした
- [SelectableDates](https://developer.android.com/reference/kotlin/androidx/compose/material3/SelectableDates) で選択できる範囲を絞った


## 動作確認方法

- ふりかえり画面で日付をタップする

## スクリーンショット


|  Before  |  After  | Design |
| ---- | ---- | ---- |
|  ![47-after](https://github.com/user-attachments/assets/c5b9f9fb-7f59-4c02-8c45-634381250e12) |  ![43-after-1](https://github.com/user-attachments/assets/e2c49023-86c0-4c9c-ab35-d3e2d86a83bd) |  ![image](https://github.com/user-attachments/assets/c22ee259-cb9f-4e3e-93fe-2e61ab2f5526) |
|  XXX  |  ![43-after-2](https://github.com/user-attachments/assets/e9dafa57-4784-4038-b406-848ddf864b9a) |  XXX |

## その他

- 色やスタイルは決まっていないのでまだ
- 画面のUIもまだ（あくまで今回は日付選択のUI作成）
