### PR TITLE
[D100P-51] バリデーションを作成する

### DIFF
--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/component/SectionTitleLabel.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/component/SectionTitleLabel.kt
@@ -1,0 +1,32 @@
+package com.rnk0085.selfcare.ui.screen.reflection.component
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.rnk0085.selfcare.ui.theme.SelfcareTheme
+import com.rnk0085.selfcare.ui.theme.sectionContentColor
+
+@Composable
+internal fun SectionTitleLabel(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.titleMedium,
+        color = sectionContentColor,
+        modifier = modifier,
+    )
+}
+
+@Preview
+@Composable
+private fun SectionTitleLabelPreview() {
+    SelfcareTheme {
+        SectionTitleLabel(
+            text = "タイトル",
+        )
+    }
+}

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/component/ValidationText.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/component/ValidationText.kt
@@ -1,0 +1,31 @@
+package com.rnk0085.selfcare.ui.screen.reflection.component
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.rnk0085.selfcare.ui.theme.SelfcareTheme
+
+@Composable
+internal fun ValidationText(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.error,
+        modifier = modifier,
+    )
+}
+
+@Preview
+@Composable
+private fun ValidationTextPreview() {
+    SelfcareTheme {
+        ValidationText(
+            text = "Validation text",
+        )
+    }
+}

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/screen/ReflectionScreen.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/screen/ReflectionScreen.kt
@@ -68,6 +68,10 @@ private fun ReflectionScreen(
                 PrimaryButton(
                     text = stringResource(R.string.record_button_text),
                     onClick = onRecordClick,
+                    enabled = uiState.selectedMood != null
+                            && uiState.firstText.isNotEmpty()
+                            && uiState.secondText.isNotEmpty()
+                            && uiState.thirdText.isNotEmpty(),
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = Spacing.Large),

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/screen/ReflectionScreen.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/screen/ReflectionScreen.kt
@@ -68,10 +68,10 @@ private fun ReflectionScreen(
                 PrimaryButton(
                     text = stringResource(R.string.record_button_text),
                     onClick = onRecordClick,
-                    enabled = uiState.selectedMood != null
-                            && uiState.firstText.isNotEmpty()
-                            && uiState.secondText.isNotEmpty()
-                            && uiState.thirdText.isNotEmpty(),
+                    enabled = uiState.selectedMood != null &&
+                            uiState.firstText.isNotEmpty() &&
+                            uiState.secondText.isNotEmpty() &&
+                            uiState.thirdText.isNotEmpty(),
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = Spacing.Large),

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/screen/ReflectionScreen.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/screen/ReflectionScreen.kt
@@ -68,10 +68,10 @@ private fun ReflectionScreen(
                 PrimaryButton(
                     text = stringResource(R.string.record_button_text),
                     onClick = onRecordClick,
-                    enabled = uiState.selectedMood != null &&
-                            uiState.firstText.isNotEmpty() &&
-                            uiState.secondText.isNotEmpty() &&
-                            uiState.thirdText.isNotEmpty(),
+                    enabled = uiState.selectedMood != null
+                            && uiState.firstText.isNotEmpty()
+                            && uiState.secondText.isNotEmpty()
+                            && uiState.thirdText.isNotEmpty(),
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = Spacing.Large),

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/section/moodSelector/MoodSelectorSection.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/section/moodSelector/MoodSelectorSection.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -17,6 +16,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.rnk0085.selfcare.R
+import com.rnk0085.selfcare.ui.screen.reflection.component.SectionTitleLabel
 import com.rnk0085.selfcare.ui.screen.reflection.component.ValidationText
 import com.rnk0085.selfcare.ui.theme.SelfcareTheme
 import com.rnk0085.selfcare.ui.theme.Spacing
@@ -36,9 +36,8 @@ internal fun MoodSelectorSection(
             .padding(all = Spacing.Large),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Text(
+        SectionTitleLabel(
             text = stringResource(R.string.mood_selector_label),
-            style = MaterialTheme.typography.labelMedium,
         )
 
         Spacer(modifier = Modifier.height(Spacing.Small))

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/section/moodSelector/MoodSelectorSection.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/section/moodSelector/MoodSelectorSection.kt
@@ -57,7 +57,9 @@ internal fun MoodSelectorSection(
 
         Spacer(modifier = Modifier.height(Spacing.Small))
 
-        if (selectedMood == null) {
+        if (
+            selectedMood == null
+        ) {
             ValidationText(
                 text = stringResource(R.string.mood_selector_validation_label),
                 modifier = Modifier

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/section/moodSelector/MoodSelectorSection.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/section/moodSelector/MoodSelectorSection.kt
@@ -57,9 +57,7 @@ internal fun MoodSelectorSection(
 
         Spacer(modifier = Modifier.height(Spacing.Small))
 
-        if (
-            selectedMood == null
-        ) {
+        if (selectedMood == null) {
             ValidationText(
                 text = stringResource(R.string.mood_selector_validation_label),
                 modifier = Modifier

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/section/moodSelector/MoodSelectorSection.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/section/moodSelector/MoodSelectorSection.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.rnk0085.selfcare.R
+import com.rnk0085.selfcare.ui.screen.reflection.component.ValidationText
 import com.rnk0085.selfcare.ui.theme.SelfcareTheme
 import com.rnk0085.selfcare.ui.theme.Spacing
 import com.rnk0085.selfcare.ui.theme.sectionContainerColor
@@ -53,6 +54,17 @@ internal fun MoodSelectorSection(
                     onClick = { onMoodSelected(mood) },
                 )
             }
+        }
+
+        Spacer(modifier = Modifier.height(Spacing.Small))
+
+        if (selectedMood == null) {
+            ValidationText(
+                text = "※どれか一つを選択してください",
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = Spacing.Small),
+            )
         }
     }
 }

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/section/moodSelector/MoodSelectorSection.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/section/moodSelector/MoodSelectorSection.kt
@@ -59,7 +59,7 @@ internal fun MoodSelectorSection(
 
         if (selectedMood == null) {
             ValidationText(
-                text = "※どれか一つを選択してください",
+                text = stringResource(R.string.mood_selector_validation_label),
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = Spacing.Small),

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/section/threeGoodThings/ThreeGoodThingsSection.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/section/threeGoodThings/ThreeGoodThingsSection.kt
@@ -55,7 +55,7 @@ internal fun ThreeGoodThingsSection(
 
         if (goodThingItems.any { it.value.isBlank() }) {
             ValidationText(
-                text = "※3つ記入してください",
+                text = stringResource(R.string.three_good_things_validation_label),
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = Spacing.Small),

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/section/threeGoodThings/ThreeGoodThingsSection.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/section/threeGoodThings/ThreeGoodThingsSection.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.rnk0085.selfcare.R
+import com.rnk0085.selfcare.ui.screen.reflection.component.ValidationText
 import com.rnk0085.selfcare.ui.theme.SelfcareTheme
 import com.rnk0085.selfcare.ui.theme.Spacing
 
@@ -45,6 +46,17 @@ internal fun ThreeGoodThingsSection(
                 placeHolderText = goodThingItem.placeHolderText,
                 value = goodThingItem.value,
                 onValueChange = goodThingItem.onValueChange,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = Spacing.Small),
+            )
+        }
+
+        Spacer(modifier = Modifier.height(Spacing.Medium))
+
+        if (goodThingItems.any { it.value.isBlank() }) {
+            ValidationText(
+                text = "※3つ記入してください",
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = Spacing.Small),

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/section/threeGoodThings/ThreeGoodThingsSection.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/section/threeGoodThings/ThreeGoodThingsSection.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -16,6 +15,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.rnk0085.selfcare.R
+import com.rnk0085.selfcare.ui.screen.reflection.component.SectionTitleLabel
 import com.rnk0085.selfcare.ui.screen.reflection.component.ValidationText
 import com.rnk0085.selfcare.ui.theme.SelfcareTheme
 import com.rnk0085.selfcare.ui.theme.Spacing
@@ -33,9 +33,8 @@ internal fun ThreeGoodThingsSection(
             .padding(vertical = Spacing.Large),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Text(
+        SectionTitleLabel(
             text = stringResource(R.string.three_good_things_label),
-            style = MaterialTheme.typography.labelMedium,
         )
 
         goodThingItems.forEach { goodThingItem ->

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/section/threeGoodThings/ThreeGoodThingsSection.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/section/threeGoodThings/ThreeGoodThingsSection.kt
@@ -53,9 +53,7 @@ internal fun ThreeGoodThingsSection(
 
         Spacer(modifier = Modifier.height(Spacing.Medium))
 
-        if (
-            goodThingItems.any { it.value.isBlank() }
-        ) {
+        if (goodThingItems.any { it.value.isBlank() }) {
             ValidationText(
                 text = stringResource(R.string.three_good_things_validation_label),
                 modifier = Modifier

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/section/threeGoodThings/ThreeGoodThingsSection.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/section/threeGoodThings/ThreeGoodThingsSection.kt
@@ -53,7 +53,9 @@ internal fun ThreeGoodThingsSection(
 
         Spacer(modifier = Modifier.height(Spacing.Medium))
 
-        if (goodThingItems.any { it.value.isBlank() }) {
+        if (
+            goodThingItems.any { it.value.isBlank() }
+        ) {
             ValidationText(
                 text = stringResource(R.string.three_good_things_validation_label),
                 modifier = Modifier

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,8 @@
     <string name="reflection_top_bar_title">ふりかえり</string>
     <string name="mood_selector_label">どのような1日でしたか？</string>
     <string name="three_good_things_label">3つのGoodなことは？</string>
+    <string name="mood_selector_validation_label">※どれか1つを選択してください</string>
+    <string name="three_good_things_validation_label">※3つ記入してください</string>
     <string name="good_thing_place_holder_text_first">ごはんが美味しかった</string>
     <string name="good_thing_place_holder_text_second">暖かいお布団で寝られてしあわせ</string>
     <string name="good_thing_place_holder_text_third">猫がかわいくて癒された〜</string>


### PR DESCRIPTION
## 概要

- 記載しないと記録できないようにした

### チケット番号

D100P-51

## やったこと

- デザイン作成
- UI修正


## 動作確認方法

ふりかえり画面で以下を確認する

- 気分アイコンが未選択状態だとエラー文が出る
- 3つ記入されていないとエラー文が出る
- エラー文が出ているとボタンが非活性になる

## スクリーンショット

[Figma](https://www.figma.com/design/dNmb8CD1GUmav5MiOTI9Nb/D-100-Project%EF%BC%9A%E3%82%BB%E3%83%AB%E3%83%95%E3%82%B1%E3%82%A2%E6%97%A5%E8%A8%98?node-id=69-303&t=ufdb3XRwnAmVXxm5-4)

|  Before  |  After  | Design |
| ---- | ---- | ---- |
|  ![51-before](https://github.com/user-attachments/assets/1ddc9e53-0982-4ee7-86a9-0df8b2907566)  |  ![51-after](https://github.com/user-attachments/assets/5c8eda14-ed83-4cc3-8e05-d56731e01fe4)  |  ![image](https://github.com/user-attachments/assets/ce877e9b-6fd2-48c3-b6c1-5611638efc42)  |

## その他
