### PR TITLE
[D100P-81] 記録が完了したら前画面に戻る

### DIFF
--- a/app/src/main/java/com/rnk0085/selfcare/data/DiaryRepositoryImpl.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/data/DiaryRepositoryImpl.kt
@@ -1,5 +1,7 @@
 package com.rnk0085.selfcare.data
 
+import android.content.ContentValues.TAG
+import android.util.Log
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 import com.rnk0085.selfcare.domain.model.Diary
@@ -13,10 +15,10 @@ class DiaryRepositoryImpl @Inject constructor() : DiaryRepository {
         database.collection(FirestoreCollecitons.DIARYS)
             .add(diary.toMap())
             .addOnSuccessListener {
-                // TODO
+                Log.d(TAG, "DocumentSnapshot added with ID: ${it.id}")
             }
             .addOnFailureListener {
-                // TODO
+                Log.w(TAG, "Error adding document", it)
             }
     }
 }

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/ReflectionUiState.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/ReflectionUiState.kt
@@ -10,6 +10,7 @@ data class ReflectionUiState(
     val firstText: String,
     val secondText: String,
     val thirdText: String,
+    val recordState: RecordState,
 ) {
     companion object {
         val InitialValue = ReflectionUiState(
@@ -19,6 +20,14 @@ data class ReflectionUiState(
             firstText = "",
             secondText = "",
             thirdText = "",
+            recordState = RecordState.Idle,
         )
     }
+}
+
+sealed class RecordState {
+    object Idle : RecordState()
+    object Loading : RecordState()
+    object Success : RecordState()
+    data class Error(val message: String) : RecordState()
 }

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/ReflectionViewModel.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/ReflectionViewModel.kt
@@ -91,7 +91,24 @@ internal class ReflectionViewModel @Inject constructor(
         )
 
         viewModelScope.launch {
-            diaryRepository.add(diary)
+            _uiState.update {
+                it.copy(recordState = RecordState.Loading)
+            }
+
+            try {
+                diaryRepository.add(diary)
+                _uiState.update {
+                    it.copy(recordState = RecordState.Success)
+                }
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(
+                        recordState = RecordState.Error(
+                            message = e.message ?: "不明なエラーが発生しました",
+                        ),
+                    )
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/ReflectionViewModel.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/ReflectionViewModel.kt
@@ -99,6 +99,7 @@ internal class ReflectionViewModel @Inject constructor(
             try {
                 diaryRepository.add(diary)
                 delay(10000)
+                throw Exception("エラー内容エラー内容エラー内容エラー内容エラー内容エラー内容エラー内容")
                 _uiState.update {
                     it.copy(recordState = RecordState.Success)
                 }
@@ -111,6 +112,12 @@ internal class ReflectionViewModel @Inject constructor(
                     )
                 }
             }
+        }
+    }
+
+    fun resetRecordState() {
+        _uiState.update {
+            it.copy(recordState = RecordState.Idle)
         }
     }
 }

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/ReflectionViewModel.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/ReflectionViewModel.kt
@@ -8,6 +8,7 @@ import com.rnk0085.selfcare.domain.model.Diary
 import com.rnk0085.selfcare.ui.currentTimeMillis
 import com.rnk0085.selfcare.ui.screen.reflection.section.moodSelector.MoodType
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -97,6 +98,7 @@ internal class ReflectionViewModel @Inject constructor(
 
             try {
                 diaryRepository.add(diary)
+                delay(10000)
                 _uiState.update {
                     it.copy(recordState = RecordState.Success)
                 }

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/ReflectionViewModel.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/ReflectionViewModel.kt
@@ -8,7 +8,6 @@ import com.rnk0085.selfcare.domain.model.Diary
 import com.rnk0085.selfcare.ui.currentTimeMillis
 import com.rnk0085.selfcare.ui.screen.reflection.section.moodSelector.MoodType
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -98,8 +97,6 @@ internal class ReflectionViewModel @Inject constructor(
 
             try {
                 diaryRepository.add(diary)
-                delay(10000)
-                throw Exception("エラー内容エラー内容エラー内容エラー内容エラー内容エラー内容エラー内容")
                 _uiState.update {
                     it.copy(recordState = RecordState.Success)
                 }

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/component/ErrorDialog.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/component/ErrorDialog.kt
@@ -1,0 +1,45 @@
+package com.rnk0085.selfcare.ui.screen.reflection.component
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.rnk0085.selfcare.R
+import com.rnk0085.selfcare.ui.theme.SelfcareTheme
+
+@Composable
+internal fun ErrorDialog(
+    message: String,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(
+                text = stringResource(R.string.error_dialog_title),
+            )
+        },
+        text = { Text(text = message) },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(R.string.ok))
+            }
+        },
+        modifier = modifier,
+    )
+}
+
+@Preview
+@Composable
+private fun ErrorDialogPreview() {
+    SelfcareTheme {
+        ErrorDialog(
+            message = "エラー内容エラー内容エラー内容エラー内容エラー内容エラー内容エラー内容",
+            onDismiss = {},
+        )
+    }
+}

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/screen/ReflectionScreen.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/screen/ReflectionScreen.kt
@@ -2,14 +2,17 @@ package com.rnk0085.selfcare.ui.screen.reflection.screen
 
 import android.content.ContentValues.TAG
 import android.util.Log
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.BottomAppBar
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -108,6 +111,16 @@ private fun ReflectionScreen(
             onSecondTextChange = onSecondTextChange,
             onThirdTextChange = onThirdTextChange,
         )
+
+        if (uiState.recordState is RecordState.Loading) {
+            // TODO: Loading 中は変更不可にする
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator()
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/screen/ReflectionScreen.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/screen/ReflectionScreen.kt
@@ -1,11 +1,14 @@
 package com.rnk0085.selfcare.ui.screen.reflection.screen
 
+import android.content.ContentValues.TAG
+import android.util.Log
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -16,6 +19,7 @@ import com.rnk0085.selfcare.R
 import com.rnk0085.selfcare.ui.screen.component.NavigationType
 import com.rnk0085.selfcare.ui.screen.component.PrimaryButton
 import com.rnk0085.selfcare.ui.screen.component.SelfcareTopAppBar
+import com.rnk0085.selfcare.ui.screen.reflection.RecordState
 import com.rnk0085.selfcare.ui.screen.reflection.ReflectionUiState
 import com.rnk0085.selfcare.ui.screen.reflection.ReflectionViewModel
 import com.rnk0085.selfcare.ui.screen.reflection.page.ReflectionPage
@@ -28,6 +32,13 @@ internal fun ReflectionScreen(
     onBackClicked: () -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(uiState.recordState) {
+        Log.d(TAG, "recordState: ${uiState.recordState}")
+        if (uiState.recordState is RecordState.Success) {
+            onBackClicked()
+        }
+    }
 
     ReflectionScreen(
         uiState = uiState,

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/screen/ReflectionScreen.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/screen/ReflectionScreen.kt
@@ -25,6 +25,7 @@ import com.rnk0085.selfcare.ui.screen.component.SelfcareTopAppBar
 import com.rnk0085.selfcare.ui.screen.reflection.RecordState
 import com.rnk0085.selfcare.ui.screen.reflection.ReflectionUiState
 import com.rnk0085.selfcare.ui.screen.reflection.ReflectionViewModel
+import com.rnk0085.selfcare.ui.screen.reflection.component.ErrorDialog
 import com.rnk0085.selfcare.ui.screen.reflection.page.ReflectionPage
 import com.rnk0085.selfcare.ui.screen.reflection.section.moodSelector.MoodType
 import com.rnk0085.selfcare.ui.theme.Spacing
@@ -54,6 +55,7 @@ internal fun ReflectionScreen(
         onSecondTextChange = viewModel::onSecondTextChange,
         onThirdTextChange = viewModel::onThirdTextChange,
         onRecordClick = viewModel::onRecordClick,
+        resetRecordState = viewModel::resetRecordState,
     )
 }
 
@@ -69,6 +71,7 @@ private fun ReflectionScreen(
     onSecondTextChange: (String) -> Unit,
     onThirdTextChange: (String) -> Unit,
     onRecordClick: () -> Unit,
+    resetRecordState: () -> Unit,
 ) {
     Scaffold(
         topBar = {
@@ -121,6 +124,13 @@ private fun ReflectionScreen(
                 CircularProgressIndicator()
             }
         }
+
+        if (uiState.recordState is RecordState.Error) {
+            ErrorDialog(
+                message = uiState.recordState.message,
+                onDismiss = resetRecordState,
+            )
+        }
     }
 }
 
@@ -138,5 +148,6 @@ private fun ReflectionScreenPreview() {
         onThirdTextChange = {},
         onBackClicked = {},
         onRecordClick = {},
+        resetRecordState = {},
     )
 }

--- a/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/screen/ReflectionScreen.kt
+++ b/app/src/main/java/com/rnk0085/selfcare/ui/screen/reflection/screen/ReflectionScreen.kt
@@ -2,6 +2,7 @@ package com.rnk0085.selfcare.ui.screen.reflection.screen
 
 import android.content.ContentValues.TAG
 import android.util.Log
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -77,7 +78,11 @@ private fun ReflectionScreen(
         topBar = {
             SelfcareTopAppBar(
                 title = stringResource(R.string.reflection_top_bar_title),
-                navigationType = NavigationType.Back(onClick = onBackClicked),
+                navigationType = if (uiState.recordState is RecordState.Loading) {
+                    null
+                } else {
+                    NavigationType.Back(onClick = onBackClicked)
+                },
             )
         },
         bottomBar = {
@@ -88,7 +93,8 @@ private fun ReflectionScreen(
                     enabled = uiState.selectedMood != null
                             && uiState.firstText.isNotEmpty()
                             && uiState.secondText.isNotEmpty()
-                            && uiState.thirdText.isNotEmpty(),
+                            && uiState.thirdText.isNotEmpty()
+                            && uiState.recordState !is RecordState.Loading,
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = Spacing.Large),
@@ -116,9 +122,10 @@ private fun ReflectionScreen(
         )
 
         if (uiState.recordState is RecordState.Loading) {
-            // TODO: Loading 中は変更不可にする
             Box(
-                modifier = Modifier.fillMaxSize(),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clickable(enabled = false) {},
                 contentAlignment = Alignment.Center,
             ) {
                 CircularProgressIndicator()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
     <string name="app_name">selfcare</string>
     <string name="ok">OK</string>
     <string name="cancel">キャンセル</string>
+    <string name="error_dialog_title">エラーが発生しました</string>
 
     <!--  ふりかえり画面  -->
     <string name="reflection_top_bar_title">ふりかえり</string>


### PR DESCRIPTION
## 概要

- Loading、Error、Success の状態を追加し分かりやすくした

### チケット番号

D100P-81

## やったこと

- 記録が完了したかどうかが一目でわかる
    - 記録中：Loading
    - 成功：前画面に戻る
    - 失敗：エラーが発生しましたダイアログ


## 動作確認方法

- ふりかえり画面で気分などを入力し、記録ボタンを押す
- Loading の確認は `delay()` を入れる
- Error の確認は `throw Exception` を入れる

## スクリーンショット



|  Loading |  Error | Design |
| ---- | ---- | ---- |
|  ![81-Loading](https://github.com/user-attachments/assets/6fab7c2b-3476-4c2f-a9e2-db9373fbadb3) |  ![81-Error](https://github.com/user-attachments/assets/353efd07-b191-4238-8e69-75284c0652f6) |  XXX  |

## その他
